### PR TITLE
update to yauzl 2.4 api

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var fs = require('fs')
 var path = require('path')
-var async = require('async')
 var yauzl = require('yauzl')
 var mkdirp = require('mkdirp')
 var concat = require('concat-stream')
@@ -17,19 +16,18 @@ module.exports = function (zipPath, opts, cb) {
   function openZip () {
     debug('opening', zipPath, 'with opts', opts)
 
-    yauzl.open(zipPath, {autoClose: false}, function (err, zipfile) {
+    yauzl.open(zipPath, {lazyEntries: true}, function (err, zipfile) {
       if (err) return cb(err)
 
       var cancelled = false
       var finished = false
 
-      var q = async.queue(extractEntry, 1)
+      zipfile.readEntry()
 
-      q.drain = function () {
-        if (!finished) return
+      zipfile.on('close', function () {
         debug('zip extraction complete')
         cb()
-      }
+      })
 
       zipfile.on('entry', function (entry) {
         if (cancelled) {
@@ -41,23 +39,20 @@ module.exports = function (zipPath, opts, cb) {
 
         if (/^__MACOSX\//.test(entry.fileName)) {
           // dir name starts with __MACOSX/
+          zipfile.readEntry()
           return
         }
 
-        q.push(entry, function (err) {
+        extractEntry(entry, function (err) {
           // if any extraction fails then abort everything
           if (err) {
             cancelled = true
-            q.kill()
             zipfile.close()
             return cb(err)
           }
           debug('finished processing', entry.fileName)
+          zipfile.readEntry()
         })
-      })
-
-      zipfile.on('end', function () {
-        finished = true
       })
 
       function extractEntry (entry, done) {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,10 @@
   },
   "homepage": "https://github.com/maxogden/extract-zip",
   "dependencies": {
-    "async": "1.5.0",
     "concat-stream": "1.5.0",
     "debug": "0.7.4",
     "mkdirp": "0.5.0",
-    "yauzl": "2.3.1"
+    "yauzl": "2.4.1"
   },
   "devDependencies": {
     "rimraf": "^2.2.8",


### PR DESCRIPTION
New yauzl version includes ZIP64 support as well as a 1-at-a-time api for entry processing (`lazyEntries: true`). I found the `lazyEntries: true` strategy to be necessary when dealing with zipfiles that contain millions of entries. See https://github.com/thejoshwolfe/yauzl/issues/22. As a bonus, it eliminates the `async` dependency for you.