### PR TITLE
Overwrite Option

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var debug = require('debug')('extract-zip')
 
 module.exports = function (zipPath, opts, cb) {
   debug('creating target directory', opts.dir)
-  opts.overwrite = opts.overwrite || false
+  opts.overwrite = (typeof opts.overwrite === 'undefined') ? true : opts.overwrite
 
   mkdirp(opts.dir, function (err) {
     if (err) return cb(err)
@@ -131,7 +131,7 @@ module.exports = function (zipPath, opts, cb) {
 
             function writeStream () {
               var writeFlag = opts.overwrite ? 'w' : 'wx'
-              var writeStream = fs.createWriteStream(dest, {mode: procMode, flag: writeFlag})
+              var writeStream = fs.createWriteStream(dest, {mode: procMode, flags: writeFlag})
               readStream.pipe(writeStream)
 
               writeStream.on('finish', function () {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "concat-stream": "1.5.0",
     "debug": "0.7.4",
     "mkdirp": "0.5.0",
-    "path-exists": "^1.0.0",
     "yauzl": "2.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "concat-stream": "1.5.0",
     "debug": "0.7.4",
     "mkdirp": "0.5.0",
+    "path-exists": "^1.0.0",
     "yauzl": "2.4.1"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -28,6 +28,25 @@ test('extract cat zip', function (t) {
   })
 })
 
+test('extract cat zip to same dir without overwrite', function (t) {
+  console.log('extracting again to', targetA)
+
+  extract(sourceA, {dir: targetA, overwrite: false}, function (err) {
+    if (err) t.ok(true, 'error passed')
+    t.end()
+  })
+})
+
+test('extract cat zip to same dir with overwrite', function (t) {
+  console.log('extracting again to', targetA)
+
+  extract(sourceA, {dir: targetA, overwrite: true}, function (err) {
+    if (err) throw err
+    t.false(err, 'no error')
+    t.end()
+  })
+})
+
 test('files', function (t) {
   t.plan(1)
 
@@ -95,6 +114,16 @@ test('verify extraction worked', function (t) {
   })
 })
 
+test('extract github zip again without overwrite', function (t) {
+  console.log('extracting again to', targetB)
+  t.plan(1)
+
+  extract(sourceB, {dir: targetB, overwrite: false}, function (err) {
+    if (err) t.ok(true, 'error passed')
+    t.end()
+  })
+})
+
 test('callback called once', function (t) {
   rimraf.sync(targetC)
 
@@ -106,9 +135,8 @@ test('callback called once', function (t) {
     if (err) throw err
 
     // this triggers an error due to symlink creation
-    extract(sourceC, {dir: targetC}, function (err) {
+    extract(sourceC, {dir: targetC, overwrite: false}, function (err) {
       if (err) t.ok(true, 'error passed')
-
       t.ok(true, 'callback called')
     })
   })


### PR DESCRIPTION
Hey @maxogden,

I created this as potential fix to #20. By default `overwrite` is true but we can toggle it off. I created a function to remove the symlink if it already exists. I added some tests but I did run into a weird issue with the last test:

```
test('callback called once', function (t) {
  rimraf.sync(targetC)
  t.plan(2)
  console.log('extracting to', targetC)
  extract(sourceC, {dir: targetC}, function (err) {
    if (err) throw err

    // this triggers an error due to symlink creation
    // NOTE the new overwrite: false option
    extract(sourceC, {dir: targetC, overwrite: false}, function (err) {
      if (err) t.ok(true, 'error passed')
      t.ok(true, 'callback called')
    })
  })
})
```

It craps out with:
```
events.js:141
      throw er; // Unhandled 'error' event
      ^
Error: EBADF: bad file descriptor, read
    at Error (native)
```

Any ideas?
Looks like this unresolved node bug: https://github.com/nodejs/node/pull/2955 && https://github.com/nodejs/node/issues/2950
