### PR TITLE
🐛 Add failsafe for detecting directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,11 @@ module.exports = function (zipPath, opts, cb) {
         var symlink = (mode & IFMT) === IFLNK
         var isDir = (mode & IFMT) === IFDIR
 
+        // Failsafe, borrowed from jsZip
+        if (!isDir && entry.fileName.slice(-1) === '/') {
+          isDir = true
+        }
+
         // check for windows weird way of specifying a directory
         // https://github.com/maxogden/extract-zip/issues/13#issuecomment-154494566
         var madeBy = entry.versionMadeBy >> 8


### PR DESCRIPTION
I think there is probably a better fix using mode constants. 

Getting the `isDir` detection wrong has a knock-on effect on the rest of the extraction and ends up throwing an EBADF error. It might be possible to do better error handling as well, however I think this fail safe would fix the majority of cases.
- uses the trailing slash as a fallback for detecting directories
- based on: https://github.com/Stuk/jszip/blob/master/lib/zipEntry.js#L155
- yauzl usage also shows detecting directories based on a trailing slash: https://github.com/thejoshwolfe/yauzl#usage
