### PR TITLE
Remove "gluten-free organic" reference from package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "extract-zip",
   "version": "1.6.0",
-  "description": "unzip a zip file into a directory using 100% pure gluten-free organic javascript",
+  "description": "unzip a zip file into a directory using 100% pure javascript",
   "main": "index.js",
   "bin": {
     "extract-zip": "cli.js"


### PR DESCRIPTION
This doesn't add to the package description at all, but could detract from it,
as many people who eat gluten-free do so because of medical reasons, not
by choice.

This was noticed when a intent to package in Debian was filed:
<https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=850254#10>.