### PR TITLE
Bump concat-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/maxogden/extract-zip",
   "dependencies": {
-    "concat-stream": "1.5.0",
+    "concat-stream": "1.6.0",
     "debug": "0.7.4",
     "mkdirp": "0.5.0",
     "yauzl": "2.4.1"


### PR DESCRIPTION
This mitigates a [possible memory disclosure vulnerability in
concat-stream 1.5.0](https://snyk.io/vuln/npm:concat-stream:20160901).