### PR TITLE
Add support for Node.js version 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - '0.10'
   - '0.12'
   - 'iojs'
   - '4.0'

--- a/index.js
+++ b/index.js
@@ -4,11 +4,12 @@ var yauzl = require('yauzl')
 var mkdirp = require('mkdirp')
 var concat = require('concat-stream')
 var debug = require('debug')('extract-zip')
+var isAbsolute = require('path-is-absolute')
 
 module.exports = function (zipPath, opts, cb) {
   debug('creating target directory', opts.dir)
 
-  if (path.isAbsolute(opts.dir) === false) {
+  if (isAbsolute(opts.dir) === false) {
     return cb(new Error('Target directory is expected to be absolute'))
   }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "concat-stream": "1.6.0",
     "debug": "2.2.0",
     "mkdirp": "0.5.0",
+    "path-is-absolute": "1.0.1",
     "yauzl": "2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi there,

[A project I maintain](https://www.npmjs.com/package/jshint) relies on this package transitively through [the `phantomjs-prebuilt` package](https://www.npmjs.com/package/phantomjs-prebuilt). Recently, we started seeing failures on our Windows build for Node.js 0.10 because of this project's [relatively new reliance on `path.isAbsolute`](https://github.com/maxogden/extract-zip/commit/01222c10101b32a657062de53e3acc2621232cd6) (a built-in method that introduced in Node 0.11).

Node 0.10 is very old, but this seems like a very minor detail for me to drop support. I can see from this project's history that it never explicitly supported that version of Node, but I figured that because the fix is so trivial, it would be worth at least asking if you folks wouldn't mind taking on the maintenance burden.

Thanks for your consideration!