### PR TITLE
extract-zip relies on outdated debug package with security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "concat-stream": "1.6.0",
-    "debug": "2.2.0",
+    "debug": "^3.1.0",
     "mkdirp": "0.5.0",
     "yauzl": "2.4.1"
   },


### PR DESCRIPTION
It looks like extract-zip requires debug@2.2.0 which is vulnerable to a [regular expression denial of service exploit](https://nodesecurity.io/advisories/534). This exploit is fixed in debug@^2.6.9 or debug@^3.1.0.
