### PR TITLE
Tiny doc improvement: Clarify that required parameters are paths

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ npm install extract-zip -g
 
 ```js
 var extract = require('extract-zip')
-extract(source, {dir: target}, function (err) {
+extract(sourcePath, {dir: targetPath}, function (err) {
  // extraction is complete. make sure to handle the err
 })
 ```


### PR DESCRIPTION
Because yauzl is able to read from buffers and file descriptors, it is not clear what `source` means in extract-zip. I fell into that trap and tried to feed it a Buffer, just to receive this not-so-obvious error:

    { Error: Path must be a string without null bytes
    at nullCheck (fs.js:117:14)
    at Object.fs.open (fs.js:543:8)
    at Object.open (/Users/xeli/Build/tresdb/node_modules/yauzl/index.js:28:6)
    at openZip (/Users/xeli/Build/tresdb/node_modules/extract-zip/index.js:30:11)
    at /Users/xeli/Build/tresdb/node_modules/extract-zip/index.js:23:7
    at LOOP (fs.js:1611:14)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9) code: 'ENOENT' }

Therefore, here I propose that readme.md is improved so that `source` is changed to `sourcePath` and `target` to `targetPath` to protect others from this trap.