### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ extract(source, {dir: target}, function (err) {
 
 ### Options
 
-- `dir` - defaults to `process.cwd()`
+- `dir` - Required - Directory to write to
 - `defaultDirMode` - integer - Directory Mode (permissions) will default to `493` (octal `0755` in integer)
 - `defaultFileMode` - integer - File Mode (permissions) will default to `420` (octal `0644` in integer)
 - `onEntry` - function - if present, will be called with `(entry, zipfile)`, entry is every entry from the zip file forwarded from the `entry` event from yauzl. `zipfile` is the `yauzl` instance


### PR DESCRIPTION
dir option is required and doesnt default to cwd as indicated in readme.