### PR TITLE
Update mkdirp version to avoid octal literal issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "concat-stream": "1.6.0",
     "debug": "2.6.9",
-    "mkdirp": "0.5.0",
+    "mkdirp": "0.5.1",
     "yauzl": "2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Octal literals are a thing of the past, it seems. The latest patch to `mkdirp` removes them, so I bumped the version.

This fixes #57.