### PR TITLE
use mkdirp 0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "concat-stream": "1.6.0",
     "debug": "2.6.9",
-    "mkdirp": "0.5.0",
+    "mkdirp": "0.5.1",
     "yauzl": "2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
there is a bug in mkdirp 0.5.0 that rollup can't parse (https://github.com/rollup/rollup/issues/361)

Fixes #57.