### PR TITLE
supports `done([error])` as optional parameter for onEntry

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ extract(source, {dir: target}, function (err) {
 - `dir` - defaults to `process.cwd()`
 - `defaultDirMode` - integer - Directory Mode (permissions) will default to `493` (octal `0755` in integer)
 - `defaultFileMode` - integer - File Mode (permissions) will default to `420` (octal `0644` in integer)
-- `onEntry` - function - if present, will be called with `(entry, zipfile)`, entry is every entry from the zip file forwarded from the `entry` event from yauzl. `zipfile` is the `yauzl` instance
+- `onEntry` - function - if present, will be called with `(entry, zipfile[, done])`, entry is every entry from the zip file forwarded from the `entry` event from yauzl. `zipfile` is the `yauzl` instance. `done` if specified is a function, to extract the entry call `done()`, if you want to fail extraction then call `done(new Error('my error message'))`.
 
 Default modes are only used if no permissions are set in the zip file.
 

--- a/test/test.js
+++ b/test/test.js
@@ -193,3 +193,56 @@ test('files in subdirs where the subdir does not have its own entry is extracted
     })
   })
 })
+
+test('onEntry gets called for each entry', function (t) {
+  t.plan(3)
+
+  var onEntryCallCount = 0
+  var options = {
+    onEntry: function (entry, zipfile) {
+      onEntryCallCount++
+    }
+  }
+  mkdtemp(t, 'files', function (dirPath) {
+    extract(catsZip, Object.assign({dir: dirPath}, options), function (err) {
+      t.notOk(err, 'no error when extracting ' + catsZip)
+      t.same(onEntryCallCount, 11, 'onEntry was called for each entry')
+    })
+  })
+})
+
+test('onEntry can stop extraction', function (t) {
+  t.plan(3)
+
+  var onEntryCallCount = 0
+  var options = {
+    onEntry: function (entry, zipfile, done) {
+      onEntryCallCount++
+      done('onEntry can stop extraction test')
+    }
+  }
+  mkdtemp(t, 'files', function (dirPath) {
+    extract(catsZip, Object.assign({dir: dirPath}, options), function (err) {
+      t.same(onEntryCallCount, 1, 'onEntry stopped extraction straight away')
+      t.ok(err, 'onEntry can stop extraction test')
+    })
+  })
+})
+
+test('onEntry allows extraction', function (t) {
+  t.plan(3)
+
+  var onEntryCallCount = 0
+  var options = {
+    onEntry: function (entry, zipfile, done) {
+      onEntryCallCount++
+      done()
+    }
+  }
+  mkdtemp(t, 'files', function (dirPath) {
+    extract(catsZip, Object.assign({dir: dirPath}, options), function (err) {
+      t.notOk(err, 'no error when extracting' + catsZip)
+      t.same(onEntryCallCount, 11, 'onEntry allowed extraction')
+    })
+  })
+})


### PR DESCRIPTION
Allows `onEntry` to receive an extra parameter that can be used to signal if the extraction should continue or fail. This allows `onEntry` to analyse the entry with libraries that return results in a callback and then signal wether extraction should continue or be cancelled. For example, using mmmagic to check that the contents of a zip are of certain file types. Useful if you are receiving untrusted zip files and want to ensure that they only contain certain types of files.