### PR TITLE
Upgrade concat-stream to 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - '0.12'
-  - 'iojs'
-  - '4'
   - '6'
   - '8'
   - '10'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "extract"
   ],
   "dependencies": {
-    "concat-stream": "1.6.2",
+    "concat-stream": "2.0.0",
     "debug": "2.6.9",
     "mkdirp": "0.5.1",
     "yauzl": "2.4.1"


### PR DESCRIPTION
This reduces the graph from 18 to 15 dependencies, mainly by
pruning dependencies only needed for EOL-versions of Node
(Node 4 and earlier).

### Before

```
+-- concat-stream@1.6.2
| +-- buffer-from@1.1.1
| +-- inherits@2.0.3
| +-- readable-stream@2.3.6
| | +-- core-util-is@1.0.2         // => removed
| | +-- isarray@1.0.0              // => removed
| | +-- process-nextick-args@2.0.0 // => removed
| | +-- safe-buffer@5.1.2
| | +-- string_decoder@1.1.1
| | `-- util-deprecate@1.0.2
| `-- typedarray@0.0.6
+-- debug@2.6.9
| `-- ms@2.0.0
+-- mkdirp@0.5.1
| `-- minimist@0.0.8
`-- yauzl@2.4.1
  `-- fd-slicer@1.0.1
    `-- pend@1.2.0
```
###  After
```
+-- concat-stream@2.0.0        // => upgraded
| +-- buffer-from@1.1.1        // same
| +-- inherits@2.0.3           // same
| +-- readable-stream@3.1.1    // => upgraded
| | +-- string_decoder@1.2.0   // => upgraded
| | | `-- safe-buffer@5.1.2    // same
| | `-- util-deprecate@1.0.2   // same
| `-- typedarray@0.0.6         // same
+-- debug@2.6.9                // same
| `-- ms@2.0.0                 // same
+-- mkdirp@0.5.1               // same
| `-- minimist@0.0.8           // same
`-- yauzl@2.4.1                // same
  `-- fd-slicer@1.0.1          // same
    `-- pend@1.2.0             // same
```

Fixes https://github.com/maxogden/extract-zip/issues/77.