### PR TITLE
Update mkdirp for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "concat-stream": "1.6.2",
     "debug": "2.6.9",
-    "mkdirp": "0.5.1",
+    "mkdirp": "0.5.3",
     "yauzl": "2.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "concat-stream": "1.6.2",
     "debug": "2.6.9",
-    "mkdirp": "0.5.3",
+    "mkdirp": ">=0.5.3 <1",
     "yauzl": "2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
minimist had to be upgraded to 1.2.3

https://www.npmjs.com/advisories/1179

Edit:

PSA: There is a TEMPORARY way to force `minimist` to a higher version. Although unlikely but it may cause other issues! Use this only until this PR gets merged!

1) Add this to the "scripts" section of your your package.json
```
    "preinstall": "npx npm-force-resolutions"
```
2) Add this to the end of your package.json
```
  "resolutions": {
    "minimist": "^1.2.5"
  }
```
3) Run `npm install`
4) Be sure to check your dependency tree with `npm ls minimist`. Only the necessarily overridden packages should be marked as invalid. (children of `extract-zip` in this case)
```
│     └─┬ extract-zip@1.6.7
│       ├── minimist@1.2.5  extraneous
│       └─┬ mkdirp@0.5.1
│         └── minimist@1.2.5  invalid
```