### PR TITLE
feat: don't pin dependency requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "extract"
   ],
   "dependencies": {
-    "concat-stream": "1.6.2",
-    "debug": "2.6.9",
-    "mkdirp": "0.5.4",
-    "yauzl": "2.4.1"
+    "concat-stream": "^1.6.2",
+    "debug": "^2.6.9",
+    "mkdirp": "^0.5.4",
+    "yauzl": "^2.10.0"
   },
   "devDependencies": {
     "rimraf": "^2.2.8",


### PR DESCRIPTION
I added the carets and then ran `yarn upgrade`.

Fixes #87.