### PR TITLE
build: lint ava tests

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+/* eslint-disable no-process-exit */
+
 var extract = require('./')
 
 var args = process.argv.slice(2)
@@ -10,11 +12,8 @@ if (!source) {
   process.exit(1)
 }
 
-extract(source, { dir: dest }, function (err, results) {
-  if (err) {
+extract(source, { dir: dest })
+  .catch(function (err) {
     console.error('error!', err)
     process.exit(1)
-  } else {
-    process.exit(0)
-  }
-})
+  })

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const debug = require('debug')('extract-zip')
+// eslint-disable-next-line node/no-unsupported-features/node-builtins
 const { createWriteStream, promises: fs } = require('fs')
 const getStream = require('get-stream')
 const path = require('path')

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "ava": "ava",
     "coverage": "nyc ava",
-    "lint": "standard",
+    "lint": "eslint .",
     "test": "npm run lint && ava"
   },
   "files": [
@@ -33,11 +33,28 @@
   },
   "devDependencies": {
     "ava": "^3.5.1",
+    "eslint": "^6.8.0",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-ava": "^10.2.0",
+    "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-node": "^11.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
     "fs-extra": "^9.0.0",
     "husky": "^4.2.3",
     "lint-staged": "^10.0.9",
-    "nyc": "^15.0.0",
-    "standard": "^14.3.3"
+    "nyc": "^15.0.0"
+  },
+  "eslintConfig": {
+    "extends": [
+      "eslint:recommended",
+      "plugin:ava/recommended",
+      "plugin:import/errors",
+      "plugin:import/warnings",
+      "plugin:node/recommended",
+      "plugin:promise/recommended",
+      "standard"
+    ]
   },
   "husky": {
     "hooks": {
@@ -45,6 +62,6 @@
     }
   },
   "lint-staged": {
-    "*.js": "standard --fix"
+    "*.js": "eslint --fix"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,10 +34,17 @@
   "devDependencies": {
     "ava": "^3.5.1",
     "fs-extra": "^9.0.0",
+    "husky": "^4.2.3",
+    "lint-staged": "^10.0.9",
     "nyc": "^15.0.0",
     "standard": "^14.3.3"
   },
-  "directories": {
-    "test": "test"
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": "standard --fix"
   }
 }


### PR DESCRIPTION
Additionally:

* build: autofix lints when committing, via `husky` & `lint-staged`
* fix(cli): adapt to Promise API

I had thought I committed the last one already, but I guess not.