### PR TITLE
Fix pipeline promise that never resolves on Node 14

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,10 @@ class Extractor {
       debug('creating symlink', link, dest)
       await fs.symlink(link, dest)
     } else {
-      await pipeline(readStream, createWriteStream(dest, { mode: procMode }))
+      await Promise.race([
+        pipeline(readStream, createWriteStream(dest, { mode: procMode })),
+        new Promise((resolve) => readStream.on('end', resolve))
+      ])
     }
   }
 


### PR DESCRIPTION
There is probably some breaking change in the promisified version of pipeline in Node.js 14.0.0; as a workaround, this PR add a listener to the `end` event of the `ReadableStream` to avoid the dead-lock.

Fixes: https://github.com/maxogden/extract-zip/issues/94