### PR TITLE
fix: correct minimum Node version based on fs.promises stability

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "extract"
   ],
   "engines": {
-    "node": ">= 10.12.0"
+    "node": ">= 10.17.0"
   },
   "dependencies": {
     "debug": "^4.1.1",


### PR DESCRIPTION
See [Node 10.17.0 release notes](https://nodejs.org/en/blog/release/v10.17.0/).

Fixes #102.
Closes #93.