### PR TITLE
feat: adding programatic filter to exclude/change file paths

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare namespace extract {
         defaultDirMode?: number;
         defaultFileMode?: number;
         onEntry?: (entry: Entry, zipfile: ZipFile) => void;
+        filter?: (entry: Entry, zipfile: ZipFile) => boolean;
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,13 @@ class Extractor {
       })
 
       this.zipfile.on('entry', async entry => {
+        if (this.opts.filter) {
+          if (!this.opts.filter(entry, this.zipfile)) {
+            this.zipfile.readEntry()
+            return
+          }
+        }
+
         /* istanbul ignore if */
         if (this.canceled) {
           debug('skipping entry', entry.fileName, { cancelled: this.canceled })

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,7 @@ async function main () {
 - `defaultDirMode` - integer - Directory Mode (permissions), defaults to `0o755`
 - `defaultFileMode` - integer - File Mode (permissions), defaults to `0o644`
 - `onEntry` - function - if present, will be called with `(entry, zipfile)`, entry is every entry from the zip file forwarded from the `entry` event from yauzl. `zipfile` is the `yauzl` instance
+- `filter` - function - if present, will be called with `(entry, zipfile)`, entry is every entry from the zip file forwarded from the `entry` event from yauzl. `zipfile` is the `yauzl` instance. If the filter returns `true` for a given file it will be extracted, else it will be skipped. It is possible to change `entry.fileName` in the filter to change the location of output files.
 
 Default modes are only used if no permissions are set in the zip file.
 

--- a/test/index.js
+++ b/test/index.js
@@ -161,3 +161,20 @@ test('extract broken zip', async t => {
     message: 'invalid central directory file header signature: 0x2014b00'
   })
 })
+
+test('filter file output', async t => {
+  const dirPath = await mkdtemp(t, 'filter-files')
+  await extract(catsZip, {
+    dir: dirPath,
+    filter: (entry, zipFile) => {
+      if (entry.fileName !== 'a-cat.png') {
+        return false
+      }
+      entry.fileName = 'bored-cat.png'
+      entry.fileNameLength = entry.fileName.length
+      return true
+    }
+  })
+  const entries = await fs.readdir(dirPath)
+  t.deepEqual(entries, ['bored-cat.png'])
+})


### PR DESCRIPTION
I had the use-case where I needed just a particular set file of a zip at a dedicated location and this function allowed me to do that rather elegantly.