### PR TITLE
docs: add description for Options properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,9 +6,18 @@ import { Entry, ZipFile } from 'yauzl';
 
 declare namespace extract {
     interface Options {
+        /** The path to the directory where the extracted files are written */
         dir: string;
+        /** Directory Mode (permissions), defaults to `0o755` */
         defaultDirMode?: number;
+        /** File Mode (permissions), defaults to `0o644` */
         defaultFileMode?: number;
+        /**
+         * If present, will be called with (entry, zipfile),
+         * entry is every entry from the zip file forwarded
+         * from the entry event from yauzl. zipfile is the
+         * yauzl instance
+         */
         onEntry?: (entry: Entry, zipfile: ZipFile) => void;
     }
 }


### PR DESCRIPTION
Descriptions from README.md.
Now, it shows useful hints on code editors.