### PR TITLE
style: fix new `standard` linting

### DIFF
--- a/.eslintrc.typescript.js
+++ b/.eslintrc.typescript.js
@@ -7,7 +7,7 @@ eslintConfig.extends.push(
 )
 
 eslintConfig.rules = {
-  'node/no-unsupported-features/es-syntax': 'off',
+  'n/no-unsupported-features/es-syntax': 'off',
   'comma-dangle': ['error', 'only-multiline'],
   semi: ['error', 'always'],
   'space-before-function-paren': ['error', 'never']

--- a/cli.js
+++ b/cli.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-/* eslint-disable no-process-exit */
+/* eslint-disable n/no-process-exit */
 
-var extract = require('./')
+const extract = require('./')
 
-var args = process.argv.slice(2)
-var source = args[0]
-var dest = args[1] || process.cwd()
+const args = process.argv.slice(2)
+const source = args[0]
+const dest = args[1] || process.cwd()
 if (!source) {
   console.error('Usage: extract-zip foo.zip <targetDirectory>')
   process.exit(1)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const debug = require('debug')('extract-zip')
-// eslint-disable-next-line node/no-unsupported-features/node-builtins
+// eslint-disable-next-line n/no-unsupported-features/node-builtins
 const { createWriteStream, promises: fs } = require('fs')
 const getStream = require('get-stream')
 const path = require('path')
@@ -106,7 +106,7 @@ class Extractor {
     const madeBy = entry.versionMadeBy >> 8
     if (!isDir) isDir = (madeBy === 0 && entry.externalFileAttributes === 16)
 
-    debug('extracting entry', { filename: entry.fileName, isDir: isDir, isSymlink: symlink })
+    debug('extracting entry', { filename: entry.fileName, isDir, isSymlink: symlink })
 
     const procMode = this.getExtractedMode(mode, isDir) & 0o777
 

--- a/package.json
+++ b/package.json
@@ -40,16 +40,15 @@
     "@types/yauzl": "^2.9.1"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.2.0",
-    "@typescript-eslint/parser": "^3.2.0",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
     "ava": "^3.5.1",
-    "eslint": "^7.2.0",
-    "eslint-config-standard": "^14.1.1",
+    "eslint": "^8.0.0",
+    "eslint-config-standard": "^17.0.0-1",
     "eslint-plugin-ava": "^10.2.0",
-    "eslint-plugin-import": "^2.20.1",
-    "eslint-plugin-node": "^11.0.0",
-    "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.1",
+    "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-n": "^14.0.0",
+    "eslint-plugin-promise": "^6.0.0",
     "fs-extra": "^9.0.0",
     "husky": "^4.2.3",
     "lint-staged": "^10.0.9",
@@ -63,7 +62,7 @@
       "plugin:ava/recommended",
       "plugin:import/errors",
       "plugin:import/warnings",
-      "plugin:node/recommended",
+      "plugin:n/recommended",
       "plugin:promise/recommended",
       "standard"
     ]


### PR DESCRIPTION
This PR update `standard` to the next version (v17) coming soon and fixes linting issues (using `standard --fix`).
This allows having the `test-external` of `standard` passing for `maxogden/extract-zip`, before releasing to stable, we ensure that the ecosystem can easily upgrade without issues.

Related: https://github.com/standard/standard/issues/1777

This new version includes:
- [`object-shorthand` rule](https://github.com/standard/eslint-config-standard/pull/166) (as warning)
- Support for ESLint v8
- `--verbose` by default